### PR TITLE
Move cache dir to /tmp and make it configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [UNRELEASED](https://github.com/hynek/setup-cached-uv/compare/v1.2.0...main)
 
+### Fixed
+
+- The cache directory couldn't actually be... cached ...due to path restrictions (anymore?) so we moved it into `/tmp/` and made it configurable using the new action input `uv-cache-dir`.
+
 
 ## [1.2.0](https://github.com/hynek/setup-cached-uv/compare/v1.1.0...v1.2.0) - 2024-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - The cache directory couldn't actually be... cached ...due to path restrictions (anymore?) so we moved it into `/tmp/` and made it configurable using the new action input `uv-cache-dir`.
+  [#8](https://github.com/hynek/setup-cached-uv/pull/8)
 
 
 ## [1.2.0](https://github.com/hynek/setup-cached-uv/compare/v1.1.0...v1.2.0) - 2024-07-22

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can change it to elsewhere using this input, but make sure, that [*actions/c
 
 #### `if-use-cache`
 
-This defaults to `true`, but can be used to disable the cache, since GitHub's default caching speed is slower than uv in many cases.
+This defaults to `true`, but can be used to disable the cache, since GitHub's default caching speed can be slower than an uncached *uv*.
 For example, if you have dependencies that don't provide prebuilt PyPy wheels, you can only cache that run like this:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Internally, the GitHub Actions function `hashFiles` is used to hash the passed p
 Using this with a fully pinned `requirements.txt` file is the most efficient use of this action because it automatically invalidates the cache.
 
 
+#### `uv-cache-path`
+
+The path to *uv*'s cache.
+Due to path restrictions, it's impossible to cache the default path, so we moved it to a path beneath `/tmp`.
+You can change it to elsewhere using this input, but make sure, that [*actions/cache*](https://github.com/actions/cache) can find it.
+
+
 #### `if-use-cache`
 
 This defaults to `true`, but can be used to disable the cache, since GitHub's default caching speed is slower than uv in many cases.

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,11 @@ inputs:
     required: false
     default: true
 
+  uv-cache-dir:
+    description: Where to put uv's cache directory.
+    required: false
+    default: /tmp/scu-uv-cache
+
 runs:
   using: composite
 
@@ -36,8 +41,8 @@ runs:
     shell: pwsh
     if: runner.os == 'Windows'
 
-  - name: Find uv cache
-    run: echo "UV_CACHE=$(uv cache dir)" >>$GITHUB_ENV
+  - name: Set uv cache directory to ${{  inputs.uv-cache-dir }}
+    run: echo "UV_CACHE_DIR=${{ inputs.uv-cache-dir }}" >>$GITHUB_ENV
     shell: bash
 
   - name: Compute cache suffix by hashing ${{ inputs.cache-dependency-path }}
@@ -52,5 +57,5 @@ runs:
     uses: actions/cache@v4
     if: inputs.use-cache-if == 'true'
     with:
-      path: ${{ env.UV_CACHE }}
+      path: ${{ env.UV_CACHE_DIR }}
       key: uv-${{ runner.os }}${{ inputs.cache-suffix }}${{ env.HASH_CACHE_SUFFIX }}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: true
 
-  uv-cache-dir:
+  uv-cache-path:
     description: Where to put uv's cache directory.
     required: false
     default: /tmp/scu-uv-cache
@@ -41,8 +41,8 @@ runs:
     shell: pwsh
     if: runner.os == 'Windows'
 
-  - name: Set uv cache directory to ${{  inputs.uv-cache-dir }}
-    run: echo "UV_CACHE_DIR=${{ inputs.uv-cache-dir }}" >>$GITHUB_ENV
+  - name: Set uv cache directory to ${{  inputs.uv-cache-path }}
+    run: echo "UV_CACHE_DIR=${{ inputs.uv-cache-path }}" >>$GITHUB_ENV
     shell: bash
 
   - name: Compute cache suffix by hashing ${{ inputs.cache-dependency-path }}


### PR DESCRIPTION
As with baipp, turns out actions/cache was claiming that the cache dir doesn't exist (it does, but some permission fubar prevents it to see it).